### PR TITLE
Update to new observers API. Remove redundant configure call.

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -269,27 +269,11 @@ Examples:
 
     },
 
-    configure: function() {
-      return {
-        src: '',
-        preventLoad: false,
-        preload: false,
-        loading: false,
-        loaded: false,
-        placeholder: null,
-        fade: false,
-        sizing: null,
-        position: 'center',
-        width: null,
-        height: null,
-      };
-    },
-
-    observers: {
-      'sizing position': 'transformChanged',
-      'canLoad preload loaded': 'loadBehaviorChanged',
-      'src preload loaded': 'loadStateChanged',
-    },
+    observers: [
+      'transformChanged(sizing, position)',
+      'loadBehaviorChanged(canLoad, preload, loaded)',
+      'loadStateChanged(src, preload, loaded)',
+    ],
 
     ready: function() {
       if (!this.hasAttribute('role')) {


### PR DESCRIPTION
This change is dependent on https://github.com/Polymer/polymer/pull/1422 being merged, and updates to match the new `observers` API, which now takes an array of string-based method signatures.

The `configure` call was also unnecessary afaict, since all properties correctly have default values specified in `properties`.  The `configure` function will likely be deprecated at some point now that we have the per-property `value` field.