### PR TITLE
finished preload description, fixed a typo

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -138,7 +138,7 @@ Examples:
       },
 
       /**
-       * When a sizing option is uzed (`cover` or `contain`), this determines
+       * When a sizing option is used (`cover` or `contain`), this determines
        * how the image is aligned within the element bounds.
        */
       position: {
@@ -148,7 +148,7 @@ Examples:
 
       /**
        * When `true`, any change to the `src` property will cause the `placeholder`
-       * image to be shown until the
+       * image to be shown until the new image has loaded.
        */
       preload: {
         type: Boolean,


### PR DESCRIPTION
preload had incomplete docs. Elsewhere, the word "used" was spelled "uzed" for some reason.