### PR TITLE
Add mixin support to `#placeholder`

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -143,7 +143,7 @@ Custom property | Description | Default
       },
 
       /**
-       * When a sizing option is uzed (`cover` or `contain`), this determines
+       * When a sizing option is used (`cover` or `contain`), this determines
        * how the image is aligned within the element bounds.
        */
       position: {
@@ -153,7 +153,7 @@ Custom property | Description | Default
 
       /**
        * When `true`, any change to the `src` property will cause the `placeholder`
-       * image to be shown until the
+       * image to be shown until the new image has loaded.
        */
       preload: {
         type: Boolean,

--- a/iron-image.html
+++ b/iron-image.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="../iron-flex-layout/iron-flex-layout.html">
 
 <!--
 `iron-image` is an element for displaying an image that provides useful sizing and
@@ -58,6 +58,9 @@ Examples:
     <iron-image style="width:400px; height:400px; background-color: lightgray;"
       sizing="cover" preload fade src="http://lorempixel.com/600/400"></iron-image>
 
+Custom property | Description | Default
+----------------|-------------|----------
+`--iron-image-placeholder` | Mixin applied to #placeholder | `{}`
 
 @group Iron Elements
 @element iron-image
@@ -81,6 +84,8 @@ Examples:
     #placeholder {
       background-color: inherit;
       opacity: 1;
+      @apply(--layout-fit);
+      @apply(--iron-image-placeholder);
     }
 
     #placeholder.faded-out {
@@ -138,7 +143,7 @@ Examples:
       },
 
       /**
-       * When a sizing option is used (`cover` or `contain`), this determines
+       * When a sizing option is uzed (`cover` or `contain`), this determines
        * how the image is aligned within the element bounds.
        */
       position: {
@@ -148,7 +153,7 @@ Examples:
 
       /**
        * When `true`, any change to the `src` property will cause the `placeholder`
-       * image to be shown until the new image has loaded.
+       * image to be shown until the
        */
       preload: {
         type: Boolean,
@@ -259,11 +264,11 @@ Examples:
         return '';
       }
 
-      var className = 'fit';
       if (this.loaded && this.fade) {
-        className += ' faded-out';
+        return 'faded-out';
       }
-      return className;
+
+      return '';
     },
 
     _computePlaceholderBackgroundUrl: function() {


### PR DESCRIPTION
Added application of the `--layout-fit` mixin retires the use of `/deep/`.

Addition of a `--iron-image-placeholder` mixin creates a bridge by which to customize the delivery of the applied placeholder image.