### PR TITLE
Fixes #13: adds CSS variables to set the width and height of the wrapped image

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="stylesheet" href="../../paper-styles/demo.css">
     <link rel="import" href="../iron-image.html">
 
-    <style>
+    <style is="custom-style">
       .sized {
         width: 200px;
         height: 200px;
@@ -39,6 +39,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         display: block;
         margin-bottom: 1em;
       }
+
+      #full-width-container {
+        width: 450px;
+        height: 500px;
+        background: #eef;
+      }
+
+      #full-width-container iron-image {
+        width: 100%;
+        --iron-image-width: 100%;
+      }
+
+      #full-height-container {
+        height: 300px;
+        background: #eef;
+      }
+
+      #full-height-container iron-image {
+        height: 100%;
+        --iron-image-height: 100%;
+      }
     </style>
 
   </head>
@@ -55,6 +76,16 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       <h3>Sizing: contain</h3>
       <iron-image class="sized gray" sizing="contain"  src="./polymer.svg"></iron-image>
       <iron-image class="sized gray" sizing="contain"  src="./polymer.svg"></iron-image>
+
+      <h3>Full width</h3>
+      <div id="full-width-container">
+        <iron-image class="gray" src="./polymer.svg"></iron-image>
+      </div>
+
+      <h3>Full height</h3>
+      <div id="full-height-container">
+        <iron-image class="gray" src="./polymer.svg"></iron-image>
+      </div>
 
       <h3>Preload: none</h3>
       <div class="group">

--- a/iron-image.html
+++ b/iron-image.html
@@ -61,6 +61,8 @@ Examples:
 Custom property | Description | Default
 ----------------|-------------|----------
 `--iron-image-placeholder` | Mixin applied to #placeholder | `{}`
+`--iron-image-width` | Sets the width of the wrapped image | `auto`
+`--iron-image-height` | Sets the height of the wrapped image | `auto`
 
 @group Iron Elements
 @element iron-image
@@ -75,6 +77,12 @@ Custom property | Description | Default
       display: inline-block;
       overflow: hidden;
       position: relative;
+    }
+
+    #img {
+      display: block;
+      width: var(--iron-image-width, auto);
+      height: var(--iron-image-height, auto);
     }
 
     :host([sizing]) #img {

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -19,6 +19,26 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../../polymer/polymer.html">
     <link rel="import" href="../../test-fixture/test-fixture.html">
     <link rel="import" href="../iron-image.html">
+
+    <style is="custom-style">
+      #fixed-width-container {
+        width: 500px;
+      }
+
+      #fixed-width-container iron-image {
+        width: 100%;
+        --iron-image-width: 100%;
+      }
+
+      #fixed-height-container {
+        height: 500px;
+      }
+
+      #fixed-height-container iron-image {
+        height: 100%;
+        --iron-image-height: 100%;
+      }
+    </style>
   </head>
   <body>
     <test-fixture id="TrivialImage">
@@ -26,6 +46,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <iron-image></iron-image>
       </template>
     </test-fixture>
+
+    <div id="fixed-width-container"></div>
+    <div id="fixed-height-container"></div>
+
     <script>
       suite('<iron-image>', function() {
         function randomImageUrl () {
@@ -67,6 +91,62 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
                   image.removeEventListener('loaded-changed', onLoadedChanged);
                 }
               }
+            });
+
+            image.src = randomImageUrl();
+          });
+        });
+
+        suite('--iron-image-width, --iron-image-height', function() {
+          var image;
+          var fixedWidthContainer;
+
+          setup(function() {
+            image = fixture('TrivialImage');
+
+            fixedWidthContainer = document.getElementById('fixed-width-container');
+            fixedHeightContainer = document.getElementById('fixed-height-container');
+          });
+
+          test('100% width image fills container', function(done) {
+            fixedWidthContainer.appendChild(image);
+
+            image.$.img.addEventListener('load', function onLoadedChanged(e) {
+              image.$.img.removeEventListener('load', onLoadedChanged);
+              Polymer.updateStyles();
+
+              var containerRect = fixedWidthContainer.getBoundingClientRect();
+              var ironImageRect = image.getBoundingClientRect();
+              var wrappedImageRect = image.$.img.getBoundingClientRect();
+
+              expect(containerRect.width).to.equal(500);
+              expect(ironImageRect.width).to.equal(500);
+              expect(wrappedImageRect.width).to.equal(500);
+
+              fixedWidthContainer.removeChild(image);
+              done();
+            });
+
+            image.src = randomImageUrl();
+          });
+
+          test('100% height image fills container', function(done) {
+            fixedHeightContainer.appendChild(image);
+
+            image.$.img.addEventListener('load', function onLoadedChanged(e) {
+              image.$.img.removeEventListener('load', onLoadedChanged);
+              Polymer.updateStyles();
+
+              var containerRect = fixedHeightContainer.getBoundingClientRect();
+              var ironImageRect = image.getBoundingClientRect();
+              var wrappedImageRect = image.$.img.getBoundingClientRect();
+
+              expect(containerRect.height).to.equal(500);
+              expect(ironImageRect.height).to.equal(500);
+              expect(wrappedImageRect.height).to.equal(500);
+
+              fixedHeightContainer.removeChild(image);
+              done();
             });
 
             image.src = randomImageUrl();

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -21,20 +21,20 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <link rel="import" href="../iron-image.html">
 
     <style is="custom-style">
-      #fixed-width-container {
+      .fixed-width-container {
         width: 500px;
       }
 
-      #fixed-width-container iron-image {
+      .fixed-width-container iron-image {
         width: 100%;
         --iron-image-width: 100%;
       }
 
-      #fixed-height-container {
+      .fixed-height-container {
         height: 500px;
       }
 
-      #fixed-height-container iron-image {
+      .fixed-height-container iron-image {
         height: 100%;
         --iron-image-height: 100%;
       }
@@ -47,8 +47,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </test-fixture>
 
-    <div id="fixed-width-container"></div>
-    <div id="fixed-height-container"></div>
+    <test-fixture id="FixedWidthContainer">
+      <template>
+        <div class="fixed-width-container"></div>
+      </template>
+    </test-fixture>
+
+    <test-fixture id="FixedHeightContainer">
+      <template>
+        <div class="fixed-height-container"></div>
+      </template>
+    </test-fixture>
 
     <script>
       suite('<iron-image>', function() {
@@ -100,12 +109,12 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         suite('--iron-image-width, --iron-image-height', function() {
           var image;
           var fixedWidthContainer;
+          var fixedHeightContainer;
 
           setup(function() {
             image = fixture('TrivialImage');
-
-            fixedWidthContainer = document.getElementById('fixed-width-container');
-            fixedHeightContainer = document.getElementById('fixed-height-container');
+            fixedWidthContainer = fixture('FixedWidthContainer');
+            fixedHeightContainer = fixture('FixedHeightContainer');
           });
 
           test('100% width image fills container', function(done) {

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -132,9 +132,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               var ironImageRect = fixedWidthIronImage.getBoundingClientRect();
               var wrappedImageRect = fixedWidthIronImage.$.img.getBoundingClientRect();
 
-              expect(containerRect.width).to.equal(500);
-              expect(ironImageRect.width).to.equal(500);
-              expect(wrappedImageRect.width).to.equal(500);
+              expect(containerRect.width).to.be.closeTo(500, 0.5);
+              expect(ironImageRect.width).to.be.closeTo(500, 0.5);
+              expect(wrappedImageRect.width).to.be.closeTo(500, 0.5);
 
               done();
             });
@@ -151,9 +151,9 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
               var ironImageRect = fixedHeightIronImage.getBoundingClientRect();
               var wrappedImageRect = fixedHeightIronImage.$.img.getBoundingClientRect();
 
-              expect(containerRect.height).to.equal(500);
-              expect(ironImageRect.height).to.equal(500);
-              expect(wrappedImageRect.height).to.equal(500);
+              expect(containerRect.height).to.be.closeTo(500, 0.5);
+              expect(ironImageRect.height).to.be.closeTo(500, 0.5);
+              expect(wrappedImageRect.height).to.be.closeTo(500, 0.5);
 
               done();
             });

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -49,13 +49,17 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <test-fixture id="FixedWidthContainer">
       <template>
-        <div class="fixed-width-container"></div>
+        <div class="fixed-width-container">
+          <iron-image></iron-image>
+        </div>
       </template>
     </test-fixture>
 
     <test-fixture id="FixedHeightContainer">
       <template>
-        <div class="fixed-height-container"></div>
+        <div class="fixed-height-container">
+          <iron-image></iron-image>
+        </div>
       </template>
     </test-fixture>
 
@@ -107,58 +111,54 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         });
 
         suite('--iron-image-width, --iron-image-height', function() {
-          var image;
           var fixedWidthContainer;
+          var fixedWidthIronImage;
           var fixedHeightContainer;
+          var fixedHeightIronImage;
 
           setup(function() {
-            image = fixture('TrivialImage');
             fixedWidthContainer = fixture('FixedWidthContainer');
+            fixedWidthIronImage = fixedWidthContainer.querySelector('iron-image');
             fixedHeightContainer = fixture('FixedHeightContainer');
+            fixedHeightIronImage = fixedHeightContainer.querySelector('iron-image');
           });
 
           test('100% width image fills container', function(done) {
-            fixedWidthContainer.appendChild(image);
-
-            image.$.img.addEventListener('load', function onLoadedChanged(e) {
-              image.$.img.removeEventListener('load', onLoadedChanged);
+            fixedWidthIronImage.$.img.addEventListener('load', function onLoadedChanged(e) {
+              fixedWidthIronImage.$.img.removeEventListener('load', onLoadedChanged);
               Polymer.updateStyles();
 
               var containerRect = fixedWidthContainer.getBoundingClientRect();
-              var ironImageRect = image.getBoundingClientRect();
-              var wrappedImageRect = image.$.img.getBoundingClientRect();
+              var ironImageRect = fixedWidthIronImage.getBoundingClientRect();
+              var wrappedImageRect = fixedWidthIronImage.$.img.getBoundingClientRect();
 
               expect(containerRect.width).to.equal(500);
               expect(ironImageRect.width).to.equal(500);
               expect(wrappedImageRect.width).to.equal(500);
 
-              fixedWidthContainer.removeChild(image);
               done();
             });
 
-            image.src = randomImageUrl();
+            fixedWidthIronImage.src = randomImageUrl();
           });
 
           test('100% height image fills container', function(done) {
-            fixedHeightContainer.appendChild(image);
-
-            image.$.img.addEventListener('load', function onLoadedChanged(e) {
-              image.$.img.removeEventListener('load', onLoadedChanged);
+            fixedHeightIronImage.$.img.addEventListener('load', function onLoadedChanged(e) {
+              fixedHeightIronImage.$.img.removeEventListener('load', onLoadedChanged);
               Polymer.updateStyles();
 
               var containerRect = fixedHeightContainer.getBoundingClientRect();
-              var ironImageRect = image.getBoundingClientRect();
-              var wrappedImageRect = image.$.img.getBoundingClientRect();
+              var ironImageRect = fixedHeightIronImage.getBoundingClientRect();
+              var wrappedImageRect = fixedHeightIronImage.$.img.getBoundingClientRect();
 
               expect(containerRect.height).to.equal(500);
               expect(ironImageRect.height).to.equal(500);
               expect(wrappedImageRect.height).to.equal(500);
 
-              fixedHeightContainer.removeChild(image);
               done();
             });
 
-            image.src = randomImageUrl();
+            fixedHeightIronImage.src = randomImageUrl();
           });
         });
       });


### PR DESCRIPTION
This PR adds CSS variables `--iron-image-width` and `--iron-image-height` which can be used to set the width and height properties of the image being wrapped by `iron-image`. This PR fixes #13 by making it possible to scale an `iron-image` to fit its container in one direction while maintaining the natural aspect ratio of the image. For example: `width: 100%; --iron-image-width: 100%;` will cause the `iron-image` and the image within it to fill the full width of its container.