### PR TITLE
add error property for invalid src

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -206,6 +206,15 @@ Custom property | Description | Default
       },
 
       /**
+       * Read-only value that indicates that the src was invalid
+       */
+      error: {
+        notify: true,
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * Can be used to set the width of image (e.g. via binding); size may also be
        * set via CSS.
        */
@@ -249,7 +258,7 @@ Custom property | Description | Default
 
     observers: [
       '_transformChanged(sizing, position)',
-      '_loadBehaviorChanged(canLoad, preload, loaded)',
+      '_loadBehaviorChanged(src, canLoad, preload, loaded)',
       '_loadStateChanged(src, preload, loaded)',
     ],
 
@@ -338,14 +347,22 @@ Custom property | Description | Default
 
       if (this.requiresPreload) {
         img = new Image();
-        img.src = this.src;
 
         this.loading = true;
+        this.loaded = false;
+        this.error = false;
 
         img.onload = function() {
           this.loading = false;
           this.loaded = true;
         }.bind(this);
+
+        img.onerror = function() {
+          this.error = true;
+        }.bind(this);
+
+        img.src = this.src;
+
       } else {
         this.loaded = true;
       }


### PR DESCRIPTION
fixes #36

There isn't a good way to determine if the src was invalid (404). This change adds an error property and listens for the onerror event on the Image.

It also moves the setting of img.src after the onload and onerror events to ensure that listeners are active before the src is loaded or errors out.

Finally, src was added to the _loadBehaviorChanged observer. This is required to properly handle the re-setting of src after it was set with an invalid src.