### PR TITLE
Fix for non-regular image source URLs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "iron-image",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "http://polymer.github.io/LICENSE.txt",
   "description": "An image-displaying element with lots of convenient features",
   "private": true,

--- a/iron-image.html
+++ b/iron-image.html
@@ -357,7 +357,7 @@ Custom property | Description | Default
       }
 
       if (this.sizing) {
-        this.style.backgroundImage = this.src ? 'url(' + this.src + ')': '';
+        this.style.backgroundImage = this.src ? 'url("' + this.src + '")': '';
       } else {
         this.$.img.src = this.src || '';
       }

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -66,7 +66,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script>
       suite('<iron-image>', function() {
         function randomImageUrl () {
-          return '../demo/polymer.svg?' + Math.random();
+          return '../demo/polymer.svg?filter=(braces)&random=' + Math.random();
         }
 
         var image;


### PR DESCRIPTION
Just adding quotes to the image source URL

(Added by @bicknellr: Fixes #32.)