### PR TITLE
fix missing Polymer import

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -16,6 +16,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
     <link rel="stylesheet" href="../../paper-styles/demo.css">
+    <link rel="import" href="../../polymer/polymer.html">
     <link rel="import" href="../iron-image.html">
 
 


### PR DESCRIPTION
the missing import of Polymer component caused to break the demo page on FireFox.