### PR TITLE
Added border-radius: inherit; to the #sizedImgDiv

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -82,6 +82,7 @@ Custom property | Description | Default
         @apply(--layout-fit);
 
         display: none;
+        border-radius: inherit;
       }
 
       #img {


### PR DESCRIPTION
When the iron-image gets border-radius the #sizedImgDiv overlaps the iron-image.
Let the #sizedImgDiv inherit the border radius prevents this.