### PR TITLE
Add title attribute to internal img.

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -118,7 +118,7 @@ Custom property | Description | Default
       hidden$="[[_computeImgDivHidden(sizing)]]"
       aria-hidden$="[[_computeImgDivARIAHidden(alt)]]"
       aria-label$="[[_computeImgDivARIALabel(alt, src)]]"></div>
-    <img id="img" alt$="[[alt]]" hidden$="[[_computeImgHidden(sizing)]]">
+    <img id="img" alt$="[[alt]]" title$="[[title]]" hidden$="[[_computeImgHidden(sizing)]]">
     <div id="placeholder"
       hidden$="[[_computePlaceholderHidden(preload, fade, loading, loaded)]]"
       class$="[[_computePlaceholderClassName(preload, fade, loading, loaded)]]"></div>
@@ -142,6 +142,14 @@ Custom property | Description | Default
          * A short text alternative for the image.
          */
         alt: {
+          type: String,
+          value: null
+        },
+
+        /**
+         * A short text shown along with the image, typically as a hover tooltip.
+         */
+        title: {
           type: String,
           value: null
         },

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -205,6 +205,25 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             image.src = randomImageUrl();
           });
+
+          test('img has no title by default', function() {
+            assert.isFalse(image.$.img.hasAttribute('title'));
+          });
+
+          test('img title is empty string when iron-image title text is empty string', function() {
+            image.title = '';
+
+            assert.isTrue(image.$.img.hasAttribute('title'));
+            assert.strictEqual(image.$.img.getAttribute('title'), '');
+          });
+
+          test('img title matches iron-image title text when defined', function() {
+            image.title = 'title value';
+
+            assert.isTrue(image.$.img.hasAttribute('title'));
+            assert.strictEqual(image.$.img.getAttribute('title'), 'title value');
+          });
+
         });
 
         suite('--iron-image-width, --iron-image-height', function() {


### PR DESCRIPTION
Fixes #52.

I modeled the tests after the tests for `alt`.
