### PR TITLE
Add draggableImage property

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -90,6 +90,24 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </demo-snippet>
 
       <h3>
+        <code>sizing="contain|cover"</code> with <code>draggable-image</code> allows 
+        the image to still be right clicked as well as dragged.
+      </h3>
+      <demo-snippet class="centered-demo">
+        <template>
+          <style is="custom-style">
+            #example-sizing-contain {
+              width: 150px;
+              height: 150px;
+              background: #ddd;
+            }
+          </style>
+
+          <iron-image sizing="contain" draggable-image id="example-sizing-contain" alt="The Polymer logo." src="./polymer.svg"></iron-image>
+        </template>
+      </demo-snippet>
+
+      <h3>
         Use the <code>--iron-image-width</code> property to set the width of
         the image wrapped by the <code>iron-image</code>.
       </h3>

--- a/iron-image.html
+++ b/iron-image.html
@@ -43,6 +43,11 @@ Examples:
     <iron-image style="width:400px; height:400px;" sizing="cover"
       src="http://lorempixel.com/600/400"></iron-image>
 
+  Will allow sized image be be right clicked and dragged:
+
+    <iron-image style="width:400px; height:400px;" sizing="cover"
+      draggable-image src="http://lorempixel.com/600/400"></iron-image>
+
   Will show light-gray background until the image loads:
 
     <iron-image style="width:400px; height:400px; background-color: lightgray;"
@@ -98,6 +103,16 @@ Custom property | Description | Default
         display: none;
       }
 
+      :host([draggable-image][sizing]) #img {
+        display: block;
+        height: 100%;
+        left: 0;
+        opacity: 0;
+        position: relative;
+        top: 0;
+        width: 100%;
+      }
+
       #placeholder {
         @apply(--layout-fit);
 
@@ -118,7 +133,7 @@ Custom property | Description | Default
       hidden$="[[_computeImgDivHidden(sizing)]]"
       aria-hidden$="[[_computeImgDivARIAHidden(alt)]]"
       aria-label$="[[_computeImgDivARIALabel(alt, src)]]"></div>
-    <img id="img" alt$="[[alt]]" hidden$="[[_computeImgHidden(sizing)]]">
+    <img id="img" alt$="[[alt]]" hidden$="[[_computeImgHidden(sizing, draggableImage)]]">
     <div id="placeholder"
       hidden$="[[_computePlaceholderHidden(preload, fade, loading, loaded)]]"
       class$="[[_computePlaceholderClassName(preload, fade, loading, loaded)]]"></div>
@@ -260,6 +275,16 @@ Custom property | Description | Default
           type: Number,
           value: null
         },
+
+        /**
+         * Can the <img/> be right clicked or dragged when sizing is set.
+         */
+
+        draggableImage: {
+          type: Boolean,
+          value: false,
+          reflectToAttribute: true
+        },
       },
 
       observers: [
@@ -344,7 +369,7 @@ Custom property | Description | Default
       },
 
       _computeImgHidden: function() {
-        return !!this.sizing;
+        return !!this.sizing && !this.draggableImage;
       },
 
       _widthChanged: function() {


### PR DESCRIPTION
Allows images that are sized using `sizing` to be right clicked or dragged by the user