### PR TITLE
Fix #86: Provide base URI to URL constructor.

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -396,7 +396,8 @@ Custom property | Description | Default
       },
 
       _resolveSrc: function(testSrc) {
-        return Polymer.ResolveUrl.resolveUrl(testSrc, this.ownerDocument.baseURI);
+        var baseURI = this.ownerDocument.baseURI;
+        return (new URL(Polymer.ResolveUrl.resolveUrl(testSrc, baseURI), baseURI)).href;
       }
     });
   </script>


### PR DESCRIPTION
`_resolveSrc` now returns a complete URL.