### PR TITLE
Handle a baseURI of null

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -396,8 +396,12 @@ Custom property | Description | Default
       },
 
       _resolveSrc: function(testSrc) {
-        var baseURI = /** @type {string} */(this.ownerDocument.baseURI);
-        return (new URL(Polymer.ResolveUrl.resolveUrl(testSrc, baseURI), baseURI)).href;
+        var baseURI = this.ownerDocument.baseURI;
+        var resolvedUrl = Polymer.ResolveUrl.resolveUrl(testSrc, baseURI);
+        if (baseURI) {
+          resolvedUrl = new URL(resolvedUrl, baseURI).href;
+        }
+        return resolvedUrl;
       }
     });
   </script>


### PR DESCRIPTION
When `ownerDocument.baseURI` is null (detached document, maybe some other cases), `new URL(url, baseURI)` will throw.
Only use `new URL` when `baseURI` is not null.