### PR TITLE
Placeholder didn't hide if `src` was not encoded

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -411,7 +411,7 @@ Custom property | Description | Default
       },
 
       _resolveSrc: function(testSrc) {
-        var resolved = Polymer.ResolveUrl.resolveUrl(testSrc, this.$.baseURIAnchor.href);
+        var resolved = Polymer.ResolveUrl.resolveUrl(encodeURI(testSrc), this.$.baseURIAnchor.href);
         // NOTE: Use of `URL` was removed here because IE11 doesn't support
         // constructing it. If this ends up being problematic, we should
         // consider reverting and adding the URL polyfill as a dev dependency.


### PR DESCRIPTION
Images URIs fed into `iron-image` not being properly encoded fail this check: 

```
if (this.$.img.src !== this._resolveSrc(this.src)) {
          return;
 }
```

because `this.$.img.src` gets automatically encoded but `this.src` not. `encodeURI(testSrc)` fixed the issue for me.