### PR TITLE
Set `_resolvedSrc` to the empty string when resetting the true image urls.

### DIFF
--- a/iron-image.html
+++ b/iron-image.html
@@ -370,6 +370,7 @@ Custom property | Description | Default
           return;
         }
 
+        this._resolvedSrc = '';
         this.$.img.removeAttribute('src');
         this.$.sizedImgDiv.style.backgroundImage = '';
 

--- a/test/iron-image.html
+++ b/test/iron-image.html
@@ -233,6 +233,40 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
             image.preventLoad = false;
           });
+
+          test('image is loaded when prevent-load is set to false after cycling `src`', function(done) {
+            const initialSrc = randomImageUrl();
+
+            image.addEventListener('loaded-changed', function loadedChanged() {
+              image.removeEventListener('loaded-changed', loadedChanged);
+
+              assert(image.loaded);
+              assert(!image.loading);
+              assert(!image.error);
+
+              image.preventLoad = true;
+              image.src = randomImageUrl();
+              image.src = initialSrc;
+
+              assert(!image.loaded);
+              assert(!image.loading);
+              assert(!image.error);
+
+              image.addEventListener('loaded-changed', function loadedChanged() {
+                image.removeEventListener('loaded-changed', loadedChanged);
+
+                assert(image.loaded);
+                assert(!image.loading);
+                assert(!image.error);
+
+                done();
+              });
+
+              image.preventLoad = false;
+            });
+
+            image.src = initialSrc;
+          });
         });
 
         suite('--iron-image-width, --iron-image-height', function() {


### PR DESCRIPTION
(Fixes #122.)